### PR TITLE
Configure smtp port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER Juan Luis Baptiste juan.baptiste@gmail.com
 
 RUN yum install -y epel-release && yum update -y && \
     yum install -y cyrus-sasl cyrus-sasl-plain cyrus-sasl-md5 mailx \
-    perl supervisor postfix rsyslog
+    perl supervisor postfix rsyslog \
+    && rm -rf /var/cache/yum/* \
+    && yum clean all
 RUN sed -i -e "s/^nodaemon=false/nodaemon=true/" /etc/supervisord.conf
 RUN sed -i -e 's/inet_interfaces = localhost/inet_interfaces = all/g' /etc/postfix/main.cf
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For more information on using multiple compose files [see here](https://docs.doc
 The following env variables need to be passed to the container:
 
 * `SMTP_SERVER` Server address of the SMTP server to use.
+* `SMTP_PORT` (Optional, Default value: 587) Port address of the SMTP server to use.
 * `SMTP_USERNAME` Username to authenticate with.
 * `SMTP_PASSWORD` Password of the SMTP user.
 * `SERVER_HOSTNAME` Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.

--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,8 @@ function add_config_value() {
 [ -z "${SMTP_PASSWORD}" ] && echo "SMTP_PASSWORD is not set" && exit 1
 [ -z "${SERVER_HOSTNAME}" ] && echo "SERVER_HOSTNAME is not set" && exit 1
 
+SMTP_PORT="${SMTP_PORT-587}"
+
 #Get the domain from the server host name
 DOMAIN=`echo ${SERVER_HOSTNAME} |awk -F. '{$1="";OFS="." ; print $0}' | sed 's/^.//'`
 
@@ -28,7 +30,7 @@ add_config_value "myhostname" ${SERVER_HOSTNAME}
 add_config_value "mydomain" ${DOMAIN}
 add_config_value "mydestination" '$myhostname'
 add_config_value "myorigin" '$mydomain'
-add_config_value "relayhost" "[${SMTP_SERVER}]:587"
+add_config_value "relayhost" "[${SMTP_SERVER}]:${SMTP_PORT}"
 add_config_value "smtp_use_tls" "yes"
 add_config_value "smtp_sasl_auth_enable" "yes"
 add_config_value "smtp_sasl_password_maps" "hash:\/etc\/postfix\/sasl_passwd"
@@ -39,7 +41,7 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
   grep -q "${SMTP_SERVER}" /etc/postfix/sasl_passwd  > /dev/null 2>&1
   if [ $? -gt 0 ]; then
     echo "Adding SASL authentication configuration"
-    echo "[${SMTP_SERVER}]:587 ${SMTP_USERNAME}:${SMTP_PASSWORD}" >> /etc/postfix/sasl_passwd
+    echo "[${SMTP_SERVER}]:${SMTP_PORT} ${SMTP_USERNAME}:${SMTP_PASSWORD}" >> /etc/postfix/sasl_passwd
     postmap /etc/postfix/sasl_passwd
   fi
 fi


### PR DESCRIPTION
https://cloud.google.com/compute/docs/tutorials/sending-mail/?hl=en
> Google Compute Engine does not allow outbound connections on ports 25, 465, and 587.