### PR TITLE
Replace add_config_value with native postconf

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -22,7 +22,6 @@ postconf -e "smtp_use_tls = yes"
 postconf -e "smtp_sasl_auth_enable = yes"
 postconf -e "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd"
 postconf -e "smtp_sasl_security_options = noanonymous"
-postconf -e "smtp_sasl_tls_security_options = noanonymous"
 
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd ]; then

--- a/run.sh
+++ b/run.sh
@@ -2,19 +2,6 @@
 
 [ "${DEBUG}" == "yes" ] && set -x
 
-function add_config_value() {
-  local key=${1}
-  local value=${2}
-  local config_file=${3:-/etc/postfix/main.cf}
-  [ "${key}" == "" ] && echo "ERROR: No key set !!" && exit 1
-  [ "${value}" == "" ] && echo "ERROR: No value set !!" && exit 1
-
-  echo "Setting configuration option ${key} with value: ${value}"
-  sed -i -e "/^#\?\(\s*${key}\s*=\s*\).*/{s//\1${value}/;:a;n;:ba;q}" \
-         -e "\$a${key}=${value}" \
-         ${config_file}
-}
-
 [ -z "${SMTP_SERVER}" ] && echo "SMTP_SERVER is not set" && exit 1
 [ -z "${SMTP_USERNAME}" ] && echo "SMTP_USERNAME is not set" && exit 1
 [ -z "${SMTP_PASSWORD}" ] && echo "SMTP_PASSWORD is not set" && exit 1
@@ -26,15 +13,16 @@ SMTP_PORT="${SMTP_PORT-587}"
 DOMAIN=`echo ${SERVER_HOSTNAME} |awk -F. '{$1="";OFS="." ; print $0}' | sed 's/^.//'`
 
 # Set needed config options
-add_config_value "myhostname" ${SERVER_HOSTNAME}
-add_config_value "mydomain" ${DOMAIN}
-add_config_value "mydestination" '$myhostname'
-add_config_value "myorigin" '$mydomain'
-add_config_value "relayhost" "[${SMTP_SERVER}]:${SMTP_PORT}"
-add_config_value "smtp_use_tls" "yes"
-add_config_value "smtp_sasl_auth_enable" "yes"
-add_config_value "smtp_sasl_password_maps" "hash:\/etc\/postfix\/sasl_passwd"
-add_config_value "smtp_sasl_security_options" "noanonymous"
+postconf -e "myhostname = ${SERVER_HOSTNAME}"
+postconf -e "mydomain = ${DOMAIN}"
+postconf -e "mydestination = $myhostname"
+postconf -e "myorigin = \$mydomain"
+postconf -e "relayhost = [${SMTP_SERVER}]:${SMTP_PORT}"
+postconf -e "smtp_use_tls = yes"
+postconf -e "smtp_sasl_auth_enable = yes"
+postconf -e "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd"
+postconf -e "smtp_sasl_security_options = noanonymous"
+postconf -e "smtp_sasl_tls_security_options = noanonymous"
 
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd ]; then

--- a/run.sh
+++ b/run.sh
@@ -15,8 +15,8 @@ DOMAIN=`echo ${SERVER_HOSTNAME} |awk -F. '{$1="";OFS="." ; print $0}' | sed 's/^
 # Set needed config options
 postconf -e "myhostname = ${SERVER_HOSTNAME}"
 postconf -e "mydomain = ${DOMAIN}"
-postconf -e "mydestination = $myhostname"
-postconf -e "myorigin = \$mydomain"
+postconf -e 'mydestination = $myhostname'
+postconf -e 'myorigin = $mydomain'
 postconf -e "relayhost = [${SMTP_SERVER}]:${SMTP_PORT}"
 postconf -e "smtp_use_tls = yes"
 postconf -e "smtp_sasl_auth_enable = yes"

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,6 @@ function add_config_value() {
  postconf -e "${key} = ${value}"
 }
 
-
 [ -z "${SMTP_SERVER}" ] && echo "SMTP_SERVER is not set" && exit 1
 [ -z "${SMTP_USERNAME}" ] && echo "SMTP_USERNAME is not set" && exit 1
 [ -z "${SMTP_PASSWORD}" ] && echo "SMTP_PASSWORD is not set" && exit 1
@@ -34,7 +33,6 @@ add_config_value "smtp_use_tls" "yes"
 add_config_value "smtp_sasl_auth_enable" "yes"
 add_config_value "smtp_sasl_password_maps" "hash:\/etc\/postfix\/sasl_passwd"
 add_config_value "smtp_sasl_security_options" "noanonymous"
-
 
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd ]; then

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,18 @@
 
 [ "${DEBUG}" == "yes" ] && set -x
 
+function add_config_value() {
+  local key=${1}
+  local value=${2}
+  local config_file=${3:-/etc/postfix/main.cf}
+  [ "${key}" == "" ] && echo "ERROR: No key set !!" && exit 1
+  [ "${value}" == "" ] && echo "ERROR: No value set !!" && exit 1
+
+  echo "Setting configuration option ${key} with value: ${value}"
+ postconf -e "${key} = ${value}"
+}
+
+
 [ -z "${SMTP_SERVER}" ] && echo "SMTP_SERVER is not set" && exit 1
 [ -z "${SMTP_USERNAME}" ] && echo "SMTP_USERNAME is not set" && exit 1
 [ -z "${SMTP_PASSWORD}" ] && echo "SMTP_PASSWORD is not set" && exit 1
@@ -13,15 +25,16 @@ SMTP_PORT="${SMTP_PORT-587}"
 DOMAIN=`echo ${SERVER_HOSTNAME} |awk -F. '{$1="";OFS="." ; print $0}' | sed 's/^.//'`
 
 # Set needed config options
-postconf -e "myhostname = ${SERVER_HOSTNAME}"
-postconf -e "mydomain = ${DOMAIN}"
-postconf -e 'mydestination = $myhostname'
-postconf -e 'myorigin = $mydomain'
-postconf -e "relayhost = [${SMTP_SERVER}]:${SMTP_PORT}"
-postconf -e "smtp_use_tls = yes"
-postconf -e "smtp_sasl_auth_enable = yes"
-postconf -e "smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd"
-postconf -e "smtp_sasl_security_options = noanonymous"
+add_config_value "myhostname" ${SERVER_HOSTNAME}
+add_config_value "mydomain" ${DOMAIN}
+add_config_value "mydestination" '$myhostname'
+add_config_value "myorigin" '$mydomain'
+add_config_value "relayhost" "[${SMTP_SERVER}]:${SMTP_PORT}"
+add_config_value "smtp_use_tls" "yes"
+add_config_value "smtp_sasl_auth_enable" "yes"
+add_config_value "smtp_sasl_password_maps" "hash:\/etc\/postfix\/sasl_passwd"
+add_config_value "smtp_sasl_security_options" "noanonymous"
+
 
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd ]; then


### PR DESCRIPTION
This project saved me a lot of time. With the basic service running in docker I was able to add TLS and authentication for external clients. I am hoping I can help in some small way.