### PR TITLE
Add some security related things.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -46,5 +46,10 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
   fi
 fi
 
+#Additional security related steps
+postconf -e 'disable_vrfy_command = yes'
+postconf -e 'smtpd_delay_reject = yes'
+postfonf -e 'smtpd_helo_required = yes'
+
 #Start services
 supervisord


### PR DESCRIPTION
Found the following items at https://upcloud.com/community/tutorials/secure-postfix-using-lets-encrypt/ and they appear to be useful.
From http://www.postfix.org/postconf.5.html
Disable the SMTP VRFY command. This stops some techniques used to harvest email addresses.
Require that a remote SMTP client sends HELO or EHLO before commencing a MAIL transaction.

Not 100% sure on the smtpd_helo_required bit, but every time I test with telnet I use it anyway.