### PR TITLE
Create tag for optional upstream tracking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The following env variables need to be passed to the container:
 * `SERVER_HOSTNAME` Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.
 
 The following env variable(s) are optional.
-* `HEADER_TAG` This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${HEADER_TAG}" in the email headers.
+* `SMTP_HEADER_TAG` This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${SMTP_HEADER_TAG}" in the email headers.
 
 To use this container from anywhere, the 25 port needs to be exposed to the docker host server:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The following env variables need to be passed to the container:
 * `SMTP_PASSWORD` Password of the SMTP user.
 * `SERVER_HOSTNAME` Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.
 
+The following env variable(s) are optional.
+* `HEADER_TAG` This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${HEADER_TAG}" in the email headers.
+
 To use this container from anywhere, the 25 port needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \ 

--- a/run.sh
+++ b/run.sh
@@ -47,14 +47,11 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
 fi
 
 #Set header tag
-postconf -e "header_checks = regexp:/etc/postfix/header_tag"
-if [ -z "${HEADER_TAG}" ]; then
-TAG="$RANDOM"
-else
-TAG="${HEADER_TAG}"
+if [ -z "${SMTP_HEADER_TAG}" ]; then
+  postconf -e "header_checks = regexp:/etc/postfix/header_tag"
+  echo -e "/^MIME-Version:/i PREPEND RelayTag: $SMTP_HEADER_TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $SMTP_HEADER_TAG" > /etc/postfix/header_tag
+  echo "******** Header tag is $SMTP_HEADER_TAG *********"
 fi
-echo -e "/^MIME-Version:/i PREPEND RelayTag: $TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $TAG" > /etc/postfix/header_tag
-echo "******** Header tag is $TAG *********"
 
 #Start services
 supervisord

--- a/run.sh
+++ b/run.sh
@@ -56,16 +56,5 @@ fi
 echo -e "/^MIME-Version:/i PREPEND RelayTag: $TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $TAG" > /etc/postfix/header_tag
 echo "******** Header tag is $TAG *********"
 
-# Create sasl_passwd file with auth credentials
-if [ ! -f /etc/postfix/sasl_passwd ]; then
-  grep -q "${SMTP_SERVER}" /etc/postfix/sasl_passwd  > /dev/null 2>&1
-  if [ $? -gt 0 ]; then
-    echo "Adding SASL authentication configuration"
-    echo "[${SMTP_SERVER}]:${SMTP_PORT} ${SMTP_USERNAME}:${SMTP_PASSWORD}" >> /etc/postfix/sasl_passwd
-    postmap /etc/postfix/sasl_passwd
-  fi
-fi
-
-
 #Start services
 supervisord

--- a/run.sh
+++ b/run.sh
@@ -46,11 +46,11 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
   fi
 fi
 
-#Set header tag
+#Set header tag  
 if [ -z "${SMTP_HEADER_TAG}" ]; then
   postconf -e "header_checks = regexp:/etc/postfix/header_tag"
   echo -e "/^MIME-Version:/i PREPEND RelayTag: $SMTP_HEADER_TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $SMTP_HEADER_TAG" > /etc/postfix/header_tag
-  echo "******** Header tag is $SMTP_HEADER_TAG *********"
+  echo "Setting configuration option SMTP_HEADER_TAG with value: ${SMTP_HEADER_TAG}"
 fi
 
 #Start services

--- a/run.sh
+++ b/run.sh
@@ -46,5 +46,26 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
   fi
 fi
 
+#Set header tag
+postconf -e "header_checks = regexp:/etc/postfix/header_tag"
+if [ -z "${HEADER_TAG}" ]; then
+TAG="$RANDOM"
+else
+TAG="${HEADER_TAG}"
+fi
+echo -e "/^MIME-Version:/i PREPEND RelayTag: $TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $TAG" > /etc/postfix/header_tag
+echo "******** Header tag is $TAG *********"
+
+# Create sasl_passwd file with auth credentials
+if [ ! -f /etc/postfix/sasl_passwd ]; then
+  grep -q "${SMTP_SERVER}" /etc/postfix/sasl_passwd  > /dev/null 2>&1
+  if [ $? -gt 0 ]; then
+    echo "Adding SASL authentication configuration"
+    echo "[${SMTP_SERVER}]:${SMTP_PORT} ${SMTP_USERNAME}:${SMTP_PASSWORD}" >> /etc/postfix/sasl_passwd
+    postmap /etc/postfix/sasl_passwd
+  fi
+fi
+
+
 #Start services
 supervisord

--- a/run.sh
+++ b/run.sh
@@ -47,7 +47,7 @@ if [ ! -f /etc/postfix/sasl_passwd ]; then
 fi
 
 #Set header tag  
-if [ -z "${SMTP_HEADER_TAG}" ]; then
+if [ ! -z "${SMTP_HEADER_TAG}" ]; then
   postconf -e "header_checks = regexp:/etc/postfix/header_tag"
   echo -e "/^MIME-Version:/i PREPEND RelayTag: $SMTP_HEADER_TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $SMTP_HEADER_TAG" > /etc/postfix/header_tag
   echo "Setting configuration option SMTP_HEADER_TAG with value: ${SMTP_HEADER_TAG}"


### PR DESCRIPTION
Check if user adds custom tag, if not create custom tag. Print tag to stdout, then use postconf to update settings.

I chose two headers to check against just in case one is not used for some reason (my general ignorance of emails is showing.)
http://www.postfix.org/header_checks.5.html
https://www.iana.org/assignments/message-headers/message-headers.xhtml