### PR TITLE
Add restricted networks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The following env variables need to be passed to the container:
 The following env variable(s) are optional.
 * `SMTP_HEADER_TAG` This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${SMTP_HEADER_TAG}" in the email headers.
 
+* `SMTP_NETWORKS` Setting this will allow you to add additional, comma seperated, subnets to use the relay. Used like
+    -e SMTP_NETWORKS='xxx.xxx.xxx.xxx/xx,xxx.xxx.xxx.xxx/xx'
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \ 

--- a/run.sh
+++ b/run.sh
@@ -51,5 +51,19 @@ if [ ! -z "${SMTP_HEADER_TAG}" ]; then
   echo "Setting configuration option SMTP_HEADER_TAG with value: ${SMTP_HEADER_TAG}"
 fi
 
+#Check for subnet restrictions
+nets='10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'
+if [ ! -z "${SMTP_NETWORKS}" ]; then
+        for i in $(sed 's/,/\ /g' <<<$SMTP_NETWORKS); do
+                if grep -Eq "[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}" <<<$i ; then
+                        nets+=", $i"
+                else
+                        echo "$i is not in proper IPv4 subnet format. Ignoring."
+                fi
+        done
+fi
+add_config_value "mynetworks" "${nets}"
+
+
 #Start services
 supervisord


### PR DESCRIPTION
By default, this will restrict access to the relay server to private subnets only (containers generally do not use publicly routed IPs). There is an option to add additional subnets as needed. 