### PR TITLE
Exec supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN yum install -y epel-release && yum update -y && \
 RUN sed -i -e "s/^nodaemon=false/nodaemon=true/" /etc/supervisord.conf
 RUN sed -i -e 's/inet_interfaces = localhost/inet_interfaces = all/g' /etc/postfix/main.cf
 
-COPY etc/*.conf /etc/
-COPY etc/rsyslog.d/* /etc/rsyslog.d
+COPY etc/ /etc/
 COPY run.sh /
 RUN chmod +x /run.sh
-COPY etc/supervisord.d/*.ini /etc/supervisord.d/
 RUN newaliases
 
 EXPOSE 25

--- a/run.sh
+++ b/run.sh
@@ -70,4 +70,4 @@ add_config_value "mynetworks" "${nets}"
 # starting services
 rm -f /var/spool/postfix/pid/master.pid
 
-supervisord
+exec supervisord


### PR DESCRIPTION
Hello Juan,

I was checking out the project and noticed that supervisor never acts as PID 1, the bash (from `run.sh`) is still PID 1. With exec you can replace `run.sh` with `supervisord`.

You can test signal forwarding by issuing a `docker stop`, the current image will wait 10s (default timeout) and then trigger a SIGKILL, with this patch supervisor will get the SIGTERM immediately and forward it to its child processes.

Also bundled the `COPY` statements into one to reduce number of layers.

Thanks for this project, it comes really handy :+1: 