### PR TITLE
 Adds the cyrus-sasl-login package to provide feature parity with CentOS image and fix #21.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM alpine
 MAINTAINER Juan Luis Baptiste juan.baptiste@gmail.com
 
 RUN apk update && \
-    apk add bash gawk cyrus-sasl cyrus-sasl-plain cyrus-sasl-crammd5 mailx \
-    perl supervisor postfix rsyslog \
+    apk add bash gawk cyrus-sasl cyrus-sasl-plain cyrus-sasl-login cyrus-sasl-crammd5 mailx \
+    perl supervisor postfix rsyslog && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /var/log/supervisor/ /var/run/supervisor/ && \
     sed -i -e 's/inet_interfaces = localhost/inet_interfaces = all/g' /etc/postfix/main.cf


### PR DESCRIPTION
It looks like the CentOS package for [cyrus-sasl-plain](https://centos.pkgs.org/7/centos-x86_64/cyrus-sasl-plain-2.1.26-23.el7.x86_64.rpm.html) includes both `liblogin.so` and `libplain.so` where the Alpine package [cyrus-sasl-plain](https://pkgs.alpinelinux.org/package/edge/main/x86_64/cyrus-sasl-plain) only contains `libplain.so`. It looks like the Alpine package [cyrus-sasl-login](https://pkgs.alpinelinux.org/package/edge/main/x86_64/cyrus-sasl-login) provides LOGIN functionality instead. I added this package to the `apk add` line in the Docker file.

This resolved #21 for me when trying to authenticate against Office 365.

I also noticed that the `apk add` line looked like it wasn't terminated properly which caused the `rm -rf` to be globbed into the add. I added a `&&` to resolve that issue as well.

Please let me know if you'd like any changes!