### PR TITLE
Add option always_add_missing_headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@
 
 # Optional: Set this to a mounted file containing the password, to avoid passwords in env variables.
 #SMTP_PASSWORD_FILE=
+
+# Optional: Set this to yes to always add missing From:, To:, Date: or Message-ID: headers.
+#ALWAYS_ADD_MISSING_HEADERS=yes

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following env variable(s) are optional.
 * `SMTP_PASSWORD_FILE` Setting this to a mounted file containing the password, to avoid passwords in env variables. Used like
     -e SMTP_PASSWORD_FILE=/secrets/smtp_password
     -v $(pwd)/secrets/:/secrets/
+* `ALWAYS_ADD_MISSING_HEADERS` This is related to the [always\_add\_missing\_headers](http://www.postfix.org/postconf.5.html#always_add_missing_headers) Postfix option (default: `no`). If set to `yes`, Postfix will always add missing headers among `From:`, `To:`, `Date:` or `Message-ID:`.
 
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,7 @@ add_config_value "smtp_use_tls" "yes"
 add_config_value "smtp_sasl_auth_enable" "yes"
 add_config_value "smtp_sasl_password_maps" "hash:/etc/postfix/sasl_passwd"
 add_config_value "smtp_sasl_security_options" "noanonymous"
+add_config_value "always_add_missing_headers" "${ALWAYS_ADD_MISSING_HEADERS:-no}"
 
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd ]; then


### PR DESCRIPTION
Hi @juanluisbaptiste, thanks for maintaining this project!

I'd like to propose to enable the option [always_add_missing_headers](http://www.postfix.org/postconf.5.html#always_add_missing_headers).

Indeed after doing experiments with a few CLI mailers (relying subsequently on docker-postfix), some don't actually generate a `Message-ID:` header… and this necessary field has be to be added in the message at some point! e.g. by docker-postfix itself :)
Hence this PR.