### PR TITLE
overwrite from address option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,6 @@
 
 # Optional: Set this to yes to always add missing From:, To:, Date: or Message-ID: headers.
 #ALWAYS_ADD_MISSING_HEADERS=yes
+
+# Optional: This will rewrite the from address overwriting it with the specified address for all email being relayed.
+#OVERWRITE_FROM="Your Name" <email@company.com>

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The following env variable(s) are optional.
     -v $(pwd)/secrets/:/secrets/
 * `ALWAYS_ADD_MISSING_HEADERS` This is related to the [always\_add\_missing\_headers](http://www.postfix.org/postconf.5.html#always_add_missing_headers) Postfix option (default: `no`). If set to `yes`, Postfix will always add missing headers among `From:`, `To:`, `Date:` or `Message-ID:`.
 
+* `OVERWRITE_FROM` This will rewrite the from address overwriting it with the specified address for all email being relayed. Example settings:
+    OVERWRITE_FROM=email@company.com
+    OVERWRITE_FROM="Your Name" <email@company.com>
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -68,6 +68,13 @@ if [ ! -z "${SMTP_NETWORKS}" ]; then
 fi
 add_config_value "mynetworks" "${nets}"
 
+if [ ! -z "${OVERWRITE_FROM}" ]; then
+  echo -e "/^From:.*$/ REPLACE From: $OVERWRITE_FROM" > /etc/postfix/smtp_header_checks
+  postmap /etc/postfix/smtp_header_checks
+  postconf -e 'smtp_header_checks = regexp:/etc/postfix/smtp_header_checks'
+  echo "Setting configuration option OVERWRITE_FROM with value: ${OVERWRITE_FROM}"
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before


### PR DESCRIPTION
I've added an option to enforce a specific from address. This is useful when you're using an external email relay like outlook.com (which won't accept the email unless the from address matches the logon name).