### PR TITLE
fix broken link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Clone this repo and then:
     cd docker-Postfix
     sudo docker build -t juanluisbaptiste/postfix .
 
-Or you can use the provided [docker-compose](https://github.com/juanluisbaptiste/docker-postfix/blob/master/docker-compose.overrides.yml) files:
+Or you can use the provided [docker-compose](https://github.com/juanluisbaptiste/docker-postfix/blob/master/docker-compose.override.yml) files:
 
     sudo docker-compose build
 


### PR DESCRIPTION
The docker-compose file was renamed in b549ac8228b7992e5fa712aecde9d52aecf5ebc3. However, the link reference was not updated.