### PR TITLE
Fix wrong description in .env.template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 # Optional: This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${SMTP_HEADER_TAG}" in the email headers.
 #SMTP_HEADER_TAG=
 
-# Optional: This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${SMTP_HEADER_TAG}" in the email headers.
+# Optional: Setting this will allow you to add additional, comma seperated, subnets to use the relay. Used like SMTP_NETWORKS='xxx.xxx.xxx.xxx/xx,xxx.xxx.xxx.xxx/xx'.
 #SMTP_NETWORKS=
 
 # Optional: Set this to a mounted file containing the password, to avoid passwords in env variables.


### PR DESCRIPTION
The old comment was wrongly copy-pasted. I just corrected that with the correct description from the Readme. 