### PR TITLE
Allow to use a SMTP server without authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@
 # Optional: (Default value: 587) Port address of the SMTP server to use.
 #SMTP_PORT=
 
-# Mandatory: Username to authenticate with.
+# Optional: Username to authenticate with.
 #SMTP_USERNAME=
 
-# Mandatory: Password of the SMTP user. (Not needed if SMTP_PASSWORD_FILE is used)
+# Optional (Mandatory if SMTP_USERNAME is set): Password of the SMTP user. (Not needed if SMTP_PASSWORD_FILE is used)
 #SMTP_PASSWORD=
 
 # Mandatory: Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The following env variables need to be passed to the container:
 
 * `SMTP_SERVER` Server address of the SMTP server to use.
 * `SMTP_PORT` (Optional, Default value: 587) Port address of the SMTP server to use.
-* `SMTP_USERNAME` Username to authenticate with.
-* `SMTP_PASSWORD` Password of the SMTP user. If `SMTP_PASSWORD_FILE` is set, not needed.
+* `SMTP_USERNAME` (Optional) Username to authenticate with.
+* `SMTP_PASSWORD` (Mandatory if `SMTP_USERNAME` is set) Password of the SMTP user. If `SMTP_PASSWORD_FILE` is set, not needed.
 * `SERVER_HOSTNAME` Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.
 
 The following env variable(s) are optional.

--- a/run.sh
+++ b/run.sh
@@ -17,9 +17,8 @@ function add_config_value() {
 if [ -n "${SMTP_PASSWORD_FILE}" ]; then [ -f "${SMTP_PASSWORD_FILE}" ] && read SMTP_PASSWORD < ${SMTP_PASSWORD_FILE} || echo "SMTP_PASSWORD_FILE defined, but file not existing, skipping."; fi
 
 [ -z "${SMTP_SERVER}" ] && echo "SMTP_SERVER is not set" && exit 1
-[ -z "${SMTP_USERNAME}" ] && echo "SMTP_USERNAME is not set" && exit 1
-[ -z "${SMTP_PASSWORD}" ] && echo "SMTP_PASSWORD is not set" && exit 1
 [ -z "${SERVER_HOSTNAME}" ] && echo "SERVER_HOSTNAME is not set" && exit 1
+[ ! -z "${SMTP_USERNAME}" -a -z "${SMTP_PASSWORD}" ] && echo "SMTP_USERNAME is set but SMTP_PASSWORD is not set" && exit 1
 
 SMTP_PORT="${SMTP_PORT:-587}"
 
@@ -33,9 +32,11 @@ add_config_value "mydestination" 'localhost'
 add_config_value "myorigin" '$mydomain'
 add_config_value "relayhost" "[${SMTP_SERVER}]:${SMTP_PORT}"
 add_config_value "smtp_use_tls" "yes"
-add_config_value "smtp_sasl_auth_enable" "yes"
-add_config_value "smtp_sasl_password_maps" "lmdb:/etc/postfix/sasl_passwd"
-add_config_value "smtp_sasl_security_options" "noanonymous"
+if [ ! -z "${SMTP_USERNAME}" ]; then
+  add_config_value "smtp_sasl_auth_enable" "yes"
+  add_config_value "smtp_sasl_password_maps" "lmdb:/etc/postfix/sasl_passwd"
+  add_config_value "smtp_sasl_security_options" "noanonymous"
+fi
 add_config_value "always_add_missing_headers" "${ALWAYS_ADD_MISSING_HEADERS:-no}"
 #Also use "native" option to allow looking up hosts added to /etc/hosts via
 # docker options (issue #51)
@@ -47,7 +48,7 @@ if [ "${SMTP_PORT}" = "465" ]; then
 fi
 
 # Create sasl_passwd file with auth credentials
-if [ ! -f /etc/postfix/sasl_passwd ]; then
+if [ ! -f /etc/postfix/sasl_passwd -a ! -z "${SMTP_USERNAME}" ]; then
   grep -q "${SMTP_SERVER}" /etc/postfix/sasl_passwd  > /dev/null 2>&1
   if [ $? -gt 0 ]; then
     echo "Adding SASL authentication configuration"


### PR DESCRIPTION
Makes SMTP_USERNAME (and SMTP_PASSWORD) optional.

Resolves #44