### PR TITLE
Add GitHub CI and Docker release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          images: juanluisbaptiste/postfix
+          tags: |
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+            type=semver,pattern={{version}}
+            alpine
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout with token
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.API_GITHUB_TOKEN }}
+
+      - name: Checkout without token
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Build Test
+        run: docker buildx build --load --tag test:test --file ./Dockerfile ./
+
+      - name: Version
+        if: github.event_name != 'pull_request'
+        uses: cycjimmy/semantic-release-action@v2.5.3
+        with:
+          semantic_version: 17.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_GITHUB_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,11 @@
+---
+branches:
+  - name: master
+  - name: develop
+    prerelease: true
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/github"
+    - successComment: false
+      failComment: false


### PR DESCRIPTION
This PR uses GitHub Workflows to fully automate the release process.

The CI includes automatic tagging and releasing via Semantic Release. What this means is that if you adopt Angular's commit convention, the CI will automatically tag and release every commit that you push. The way it works is simple - prefix your commit with `feat:`, and it will trigger a minor version bump. Prefix your commit with `fix:`, and it will trigger a patch version bump. Prefix with `BREAKING CHANGE:`, and it will trigger a major version bump. Everything else will not trigger a release. If you want to pre-release, use a new branch called `develop`, and the CI will take care of the rest. More information here: https://github.com/semantic-release/semantic-release

Docker images will be multi-arch (support all architectures), and have the following versions (assume we are releasing v1.0.0):
- Major (1)
- Minor (1.0)
- Patch (1.0.0)
- "latest"
- "alpine"

To use this yourself, simply add the following secrets to your GitHub repo:
- API_GITHUB_TOKEN
- DOCKER_USERNAME
- DOCKER_PASSWORD

EDIT: I see that you have a Docker Hub CI hook, if that automatically builds and releases then you will have to disable it to prevent conflicts.

Fixes #23