### PR TITLE
feat: Add ENV option to enable subject line logging #68

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@
 
 # Optional: This will use allow you to set a custom $mydestination value. Default is localhost.
 #DESTINATION=
+
+# Optional: This will output the subject line of messages in the log.
+#LOG_SUBJECT=yes

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The following env variable(s) are optional.
 
 * `DESTINATION` This will define a list of domains from which incoming messages will be accepted.
 
+* `LOG_SUBJECT` This will output the subject line of messages in the log.
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -61,9 +61,16 @@ fi
 
 #Set header tag
 if [ ! -z "${SMTP_HEADER_TAG}" ]; then
-  postconf -e "header_checks = regexp:/etc/postfix/header_tag"
-  echo -e "/^MIME-Version:/i PREPEND RelayTag: $SMTP_HEADER_TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $SMTP_HEADER_TAG" > /etc/postfix/header_tag
+  postconf -e "header_checks = regexp:/etc/postfix/header_checks"
+  echo -e "/^MIME-Version:/i PREPEND RelayTag: $SMTP_HEADER_TAG\n/^Content-Transfer-Encoding:/i PREPEND RelayTag: $SMTP_HEADER_TAG" >> /etc/postfix/header_checks
   echo "Setting configuration option SMTP_HEADER_TAG with value: ${SMTP_HEADER_TAG}"
+fi
+
+#Enable logging of subject line
+if [ "${LOG_SUBJECT}" == "yes" ]; then
+  postconf -e "header_checks = regexp:/etc/postfix/header_checks"
+  echo -e "/^Subject:/ WARN" >> /etc/postfix/header_checks
+  echo "Enabling logging of subject line"
 fi
 
 #Check for subnet restrictions


### PR DESCRIPTION
# Creating a Pull Request

We use github actions to do automatic [semantic versioning](https://github.com/semantic-release/semantic-release), so please use the following nomenclature for the commit message according to the type of change:

* Prefix with `feat:`, and it will trigger a minor version bump. 
* Prefix with `fix`:, and it will trigger a patch version bump. 
* Prefix with `BREAKING CHANGE:`, and it will trigger a major version bump.

## Description of the change
Resolves issue #68 This simply allows you to pass LOG_SUBJECT=yes as an environment variable in order to enable outputting the subject line in the logs.

## Motivation and Context
I like to see the subject line in the logs to help identify messages.

## How Has This Been Tested?
Since this change affects a file that also is related to SMTP_HEADER_TAG, I tested 4 scenarios:
1. setting neither SMTP_HEADER_TAG or LOG_SUBJECT
2. setting only SMTP_HEADER_TAG but not LOG_SUBJECT
3. setting only LOG_SUBJECT=yes but not SMTP_HEADER_TAG
4. setting both SMTP_HEADER_TAG and LOG_SUBJECT=yes

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.

And lastly, many thanks for taking your time to help us improve this project !
