### PR TITLE
feat: Add message_size_limit option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,6 @@
 # Optional: This will use allow you to set a custom $message_size_limit value. Default is 10240000.
 #MESSAGE_SIZE_LIMIT=
 
-
 # Optional: This will output the subject line of messages in the log.
 #LOG_SUBJECT=yes
 

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@
 
 # Optional: This will use allow you to set a custom $mydestination value. Default is localhost.
 #DESTINATION=
+
+# Optional: This will use allow you to set a custom $message_size_limit value. Default is 10240000.
+#MESSAGE_SIZE_LIMIT=

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The following env variable(s) are optional.
 
 * `DESTINATION` This will define a list of domains from which incoming messages will be accepted.
 
+* `MESSAGE_SIZE_LIMIT` This will change the default limit of 10240000 bytes (10MB).
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -86,6 +86,12 @@ if [ ! -z "${OVERWRITE_FROM}" ]; then
   echo "Setting configuration option OVERWRITE_FROM with value: ${OVERWRITE_FROM}"
 fi
 
+# Set message_size_limit
+if [ ! -z "${MESSAGE_SIZE_LIMIT}" ]; then
+  postconf -e "message_size_limit = ${MESSAGE_SIZE_LIMIT}"
+  echo "Setting configuration option message_size_limit with value: ${MESSAGE_SIZE_LIMIT}"
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before


### PR DESCRIPTION
## Description of the change
<!--Please be very clear on the intention of the modifications included in the pull request.-->
<!--If it is a bug, explain what is the issue at hand and how you are fixing it. -->
<!--If it is an improvement, explain why do you think it is needed and the benefits it brings to the project. -->
<!--Ideally I would recommend to create an issue first to discuss the new feature with the developers.-->

This adds the message_size_limit option to enable changing the default value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To enable sending larger messages

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->

Tested the change with a value of 34000000 (34MB) 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (adding or updating documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.

And lastly, many thanks for taking your time to help us improve this project !
