### PR TITLE
fix: Allow localhost

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -77,7 +77,7 @@ if [ "${LOG_SUBJECT}" == "yes" ]; then
 fi
 
 #Check for subnet restrictions
-nets='10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'
+nets='localhost, 127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'
 if [ ! -z "${SMTP_NETWORKS}" ]; then
   declare ipv6re="^((([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|\
     ([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|\


### PR DESCRIPTION
## Description of the change
The whitelist does not work if the container is in the host network, as postfix does not allow sending from localhost. This simple change allows localhost to send emails as well.

## Motivation and Context
Using the host network does not work.

## How Has This Been Tested?
Tested the change locally successful

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)

## Checklist:
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.

And lastly, many thanks for taking your time to help us improve this project !
