### PR TITLE
feat: Allow to override default networks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,9 @@
 # Optional: Setting this will allow you to add additional, comma seperated, subnets to use the relay. Used like SMTP_NETWORKS='xxx.xxx.xxx.xxx/xx,xxx.xxx.xxx.xxx/xx'.
 #SMTP_NETWORKS=
 
+# Optional: Setting this will allow you not to use default networks containing all private network ranges when SMTP_NETWORKS is set.
+#SMTP_NETWORKS_OVERRIDE=yes
+
 # Optional: Set this to a mounted file containing the password, to avoid passwords in env variables.
 #SMTP_PASSWORD_FILE=
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.3.1
         with:
           push: true
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.API_GITHUB_TOKEN }}
 
@@ -28,7 +28,7 @@ jobs:
             alpine
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,23 +13,23 @@ jobs:
     steps:
       - name: Checkout with token
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.API_GITHUB_TOKEN }}
 
       - name: Checkout without token
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Docker Build Test
         run: docker buildx build --load --tag test:test --file ./Dockerfile ./
 
       - name: Version
         if: github.event_name != 'pull_request'
-        uses: cycjimmy/semantic-release-action@v2.5.3
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 17.4
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Dockerfile for a Postfix email relay service
-FROM alpine:3.15
+FROM alpine:3.16
 MAINTAINER Juan Luis Baptiste juan.baptiste@gmail.com
 
 RUN apk update && \

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following env variable(s) are optional.
 
 * `SMTP_NETWORKS` Setting this will allow you to add additional, comma seperated, subnets to use the relay. Used like
     -e SMTP_NETWORKS='xxx.xxx.xxx.xxx/xx,xxx.xxx.xxx.xxx/xx'
+* `SMTP_NETWORKS_OVERRIDE` (Optional) Removes default allowed network list, that contains all private network ranges. Useful when one needs to limit access to smaller range or single IPs. To be used only with custom SMTP_NETWORKS value. 
 
 * `SMTP_PASSWORD_FILE` Setting this to a mounted file containing the password, to avoid passwords in env variables. Used like
     -e SMTP_PASSWORD_FILE=/secrets/smtp_password


### PR DESCRIPTION
## Description of the change
new ENV added which allows to override default network ranges.

## Motivation and Context
The script was initially prepared to allow connection from all private network ranges (as defined in RFC 1918).
There was an ability to extend subnets with additional networks using `SMTP_NETWORKS`. In result it was adding defined extra networks after private networks. However it there is a need to limit private networks, there was no way to do it.
After adding `SMTP_NETWORKS_OVERRIDE=yes` the script will use only networks defined in `SMTP_NETWORKS`, without putting default private networks set in front of the config.

The conception:
1. when there is no `SMTP_NETWORKS` provided, the nets should be
 `10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16`
2. when `SMTP_NETWORK` variable is set to value `1.2.3.4/32` and no `SMTP_NETWORKS_OVERRIDE` is set, nets should be 
`10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 1.2.3.4/32`
3. when `SMTP_NETWORKS="1.2.3.0/20"` and `SMTP_NETWORK_OVERRIDE=yes` 
nets needs to have value of `1.2.3.0/20`.

After a change the part of code responsible for network restrictions is more readable. The script initializes an empty array (nets) to hold the network specifications. 
If `SMTP_NETWORKS` is empty, it adds `DEFAULT_NETS` to the nets array. 
Otherwise, if `SMTP_NETWORKS_OVERRIDE` is not set to "yes", it also adds `DEFAULT_NETS` to the nets array before processing `SMTP_NETWORKS`.

The script then iterates over each network in `SMTP_NETWORKS`, validating that it matches either the IPv4 or IPv6 regular expression. If a network is valid, it adds it to the nets array. If a network is not valid, the script prints an error message and exits with a non-zero status code.

Finally, the script joins the elements of the nets array into a comma-separated string (nets_str) and use it to configure postfix.

## How Has This Been Tested?

First build the new docker image with the changed script
 `docker build -t test .`

After that verify configuration by executing command for each scenario:
1. `docker run --rm --name postfix -P  -e SMTP_SERVER=smtp.bar.com -e SERVER_HOSTNAME=localhost test`
    the output contains: 
    ```Setting configuration option mynetworks with value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16```
2. `docker run --rm --name postfix -P -e SMTP_SERVER=smtp.bar.com -e SERVER_HOSTNAME=localhost -e SMTP_NETWORKS="1.2.3.4/32" test`
   the output contains:
   ```Setting configuration option mynetworks with value: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,1.2.3.4/32```
3. `docker run --rm --name postfix -P -e SMTP_SERVER=smtp.bar.com -e SERVER_HOSTNAME=localhost -e SMTP_NETWORKS="1.2.3.0/20" -e SMTP_NETWORKS_OVERRIDE=yes test` 
   the output contains: 
   ```Setting configuration option mynetworks with value: 1.2.3.0/20```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.
