### PR TITLE
feat: Add override for origin domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@
 # Mandatory: Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.
 #SERVER_HOSTNAME=
 
+# Optional: Override origin domain. Defaults to base domain of server hostname.
+#DOMAIN=
+
 # Optional: This will add a header for tracking messages upstream. Helpful for spam filters. Will appear as "RelayTag: ${SMTP_HEADER_TAG}" in the email headers.
 #SMTP_HEADER_TAG=
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The following env variable(s) are optional.
 
 * `MESSAGE_SIZE_LIMIT` This will change the default limit of 10240000 bytes (10MB).
 
+* `DOMAIN` Override origin domain. If not set, defaults to base domain of server hostname.
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -23,8 +23,10 @@ if [ -n "${SMTP_USERNAME_FILE}" ]; then [ -e "${SMTP_USERNAME_FILE}" ] && SMTP_U
 
 SMTP_PORT="${SMTP_PORT:-587}"
 
-#Get the domain from the server host name
-DOMAIN=`echo ${SERVER_HOSTNAME} | awk 'BEGIN{FS=OFS="."}{print $(NF-1),$NF}'`
+# If not defined, get the domain from the server host name
+if [ -z "$DOMAIN" ]; then
+  DOMAIN=`echo ${SERVER_HOSTNAME} | awk 'BEGIN{FS=OFS="."}{print $(NF-1),$NF}'`
+fi
 
 # Set needed config options
 add_config_value "maillog_file" "/dev/stdout"


### PR DESCRIPTION
## Description of the change

Adding override for origin domain.

## Motivation and Context

In my case, my sending domain is `foo.bar.com` but the current script only keeps `bar.com` and my relay SMTP refuses the email.
By allowing to override the default behaviour, I can set the origin domain to the correct value.

Fixes issue: https://github.com/juanluisbaptiste/docker-postfix/issues/84

## How Has This Been Tested?
Simple bash "if value is not defined" it does the previous behaviour.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.
