### PR TITLE
Feature/8bitmime off option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The following env variable(s) are optional.
 
 * `TRANSPORT_DISCARD` This is a comma separated list of email addresses that will be discarded. These addresses will not be relayed.
 
+* `IGNORE_EHLO_8BITMIME` Appends "smtp_discard_ehlo_keywords = 8BITMIME" to /etc/postfix/main.cf, this resolves failure to send to broken/old Microsoft Exchange.  Resolves "554 5.6.1 Body type not supported by Remote Host"
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Additionally the amd64 architecture has the following tags:
 Clone this repo and then:
 
     cd docker-Postfix
-    sudo docker build -t juanluisbaptiste/postfix .
+    sudo docker build -t cyberitas/postfix .
+
+To push a multiplatform version to Docker Hub, you can use the following command:
+
+    docker buildx create --name multiplatform-builder --use
+    docker buildx build --platform linux/amd64,linux/arm64 -t cyberitas/postfix:1.7 --push .
 
 Or you can use the provided [docker-compose](https://github.com/juanluisbaptiste/docker-postfix/blob/master/docker-compose.override.yml) files:
 
@@ -45,7 +50,7 @@ Or you can use the provided [docker-compose](https://github.com/juanluisbaptiste
 
 For more information on using multiple compose files [see here](https://docs.docker.com/compose/production/). You can also find a prebuilt docker image from [Docker Hub](https://registry.hub.docker.com/u/juanluisbaptiste/postfix/), which can be pulled with this command:
 
-    sudo docker pull juanluisbaptiste/postfix:latest
+    sudo docker pull cyberitas/postfix:latest
 
 ### How to run it
 
@@ -94,7 +99,7 @@ To use this container from anywhere, the 25 port or the one specified by `SMTP_P
            -e SMTP_USERNAME=foo@bar.com \
            -e SMTP_PASSWORD=XXXXXXXX \
            -e SERVER_HOSTNAME=helpdesk.mycompany.com \
-           juanluisbaptiste/postfix
+           cyberitas/postfix
 
 If you are going to use this container from other docker containers then it's better to just publish the port:
 
@@ -103,7 +108,7 @@ If you are going to use this container from other docker containers then it's be
            -e SMTP_USERNAME=foo@bar.com \
            -e SMTP_PASSWORD=XXXXXXXX \
            -e SERVER_HOSTNAME=helpdesk.mycompany.com \           
-           juanluisbaptiste/postfix
+           cyberitas/postfix
 
 Or if you can start the service using the provided [docker-compose](https://github.com/juanluisbaptiste/docker-postfix/blob/master/docker-compose.yml) file for production use:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The following env variable(s) are optional.
 
 * `MESSAGE_SIZE_LIMIT` This will change the default limit of 10240000 bytes (10MB).
 
+* `TRANSPORT_DISCARD` This is a comma separated list of email addresses that will be discarded. These addresses will not be relayed.
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/run.sh
+++ b/run.sh
@@ -120,6 +120,18 @@ if [ ! -z "${MESSAGE_SIZE_LIMIT}" ]; then
   echo "Setting configuration option message_size_limit with value: ${MESSAGE_SIZE_LIMIT}"
 fi
 
+# Add transport discards
+if [ ! -z "${TRANSPORT_DISCARD}" ]; then
+  postconf -e "transport_maps = lmdb:/etc/postfix/transport"
+  # Split on comma
+  IFS=',' read -r -a array <<< "${TRANSPORT_DISCARD}"
+  for i in "${array[@]}"; do
+    echo "${i} discard:" >> /etc/postfix/transport
+  done
+  postmap lmdb:/etc/postfix/transport
+  echo "Setting configuration option TRANSPORT_DISCARD with value: ${TRANSPORT_DISCARD}"
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before

--- a/run.sh
+++ b/run.sh
@@ -132,6 +132,13 @@ if [ ! -z "${TRANSPORT_DISCARD}" ]; then
   echo "Setting configuration option TRANSPORT_DISCARD with value: ${TRANSPORT_DISCARD}"
 fi
 
+if [ ! -z "${IGNORE_EHLO_8BITMIME}" ]; then
+  echo "smtp_discard_ehlo_keywords = 8BITMIME" >> /etc/postfix/main.cf
+  # Older broken Microsoft Exchange advertises 8BITMIME in response to EHLO
+  # Attempting to deliver will fail with error: 554 5.6.1 Body type not supported by Remote Host
+  # Postfix main.cf 'smtp_discard_ehlo_keywords = 8BITMIME' instructs postfix to ignore the 8BITMIME
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before


### PR DESCRIPTION
## Description of the change
Add optional environment variable, when set causes postfix to ignore 8BITMIME in the EHLO response

## Motivation and Context
Older, broken Microsoft Exchange includes 8BITMIME in its EHLO response, even though it does not support it.
In this use case, you will see: "554 5.6.1 Body type not supported by Remote Host"

## How Has This Been Tested?
A Drupal CMS uses this Postfix Docker to SMTP relay email to a remote Microsoft Exchange server, without this revision email is returned with message "554 5.6.1 Body type not supported by Remote Host".
With this revision active, email is sent successfully.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ X] Documentation (adding or updating documentation)

## Checklist:
- [X ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X ] My change adds a new configuration environment variable and I have updated the `run.sh` file accordingly.
