### PR TITLE
Fix: Prevent duplicate header entries in Postfix config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 #Dockerfile for a Postfix email relay service
-FROM alpine:3.22
-LABEL org.opencontainers.image.authors="juan@juanbaptiste.tech"
+
+FROM alpine:3.16
+MAINTAINER Juan Luis Baptiste juan.baptiste@gmail.com
 
 RUN apk update && \
-    apk add bash gawk cyrus-sasl cyrus-sasl-login cyrus-sasl-crammd5 mailx \
-    postfix && \
+    apk add bash gawk cyrus-sasl cyrus-sasl-login cyrus-sasl-crammd5 mailx postfix mc && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /var/log/supervisor/ /var/run/supervisor/ && \
     sed -i -e 's/inet_interfaces = localhost/inet_interfaces = all/g' /etc/postfix/main.cf
@@ -14,5 +14,6 @@ RUN chmod +x /run.sh
 RUN newaliases
 
 EXPOSE 25
+
 #ENTRYPOINT ["/run.sh"]
 CMD ["/run.sh"]


### PR DESCRIPTION
## Fix: Prevents duplicate entries in Postfix configuration files

### Background
Each time the container was restarted, configuration lines were written multiple times to `/etc/postfix/header_checks`.

### Changes
- Check for existing lines with `grep -qxF`
- Only add if line does not exist
- Structuring with variables for better maintainability

### Test
- Multiple container restarts → no duplicates
- Functionality remains intact

### Note
The method can be easily transferred to other configuration files.