### PR TITLE
feat: add support for setting the timezone with $TZ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,6 @@
 
 # Optional: This will use allow you to set a custom $message_size_limit value. Default is 10240000.
 #MESSAGE_SIZE_LIMIT=
+
+# Optional: set the timezone in the format Europe/Berlin (see man tzset for all possible values)
+#TZ=America/Bogota

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.22
 LABEL org.opencontainers.image.authors="juan@juanbaptiste.tech"
 
 RUN apk update && \
-    apk add bash gawk cyrus-sasl cyrus-sasl-login cyrus-sasl-crammd5 mailx \
+    apk add bash gawk cyrus-sasl cyrus-sasl-login cyrus-sasl-crammd5 mailx tzdata \
     postfix && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /var/log/supervisor/ /var/run/supervisor/ && \

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following env variable(s) are optional.
 
 * `DOMAIN` Override origin domain. If not set, defaults to base domain of server hostname.
 
-* `TZ` set the timezone the container is running in. The default timezone is determined by `/etc/localtime` in the container, which typically would indicate UTC.
+* `TZ` alternative way to set the timezone, when mounting `/etc/localtime` from the host is not an option.
 
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ The following env variable(s) are optional.
 
 * `DOMAIN` Override origin domain. If not set, defaults to base domain of server hostname.
 
+* `TZ` set the timezone the container is running in. The default timezone is determined by `/etc/localtime` in the container, which typically would indicate UTC.
+
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 
     docker run -d --name postfix -p "25:25"  \

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following env variable(s) are optional.
 
 * `DOMAIN` Override origin domain. If not set, defaults to base domain of server hostname.
 
-* `TZ` alternative way to set the timezone, when mounting `/etc/localtime` from the host is not an option.
+* `TZ` alternative way to set the timezone, when mounting `/etc/localtime` from the host is not an option (i.e. in Kubernetes).
 
 To use this container from anywhere, the 25 port or the one specified by `SMTP_PORT` needs to be exposed to the docker host server:
 


### PR DESCRIPTION
## Description of the change
This allows users of the container to simply set the timezone using `TZ` environment variable.

## Motivation and Context
On host systems like talos linux the timezone of the kubernetes worker is fixed by definition to UTC, so mounting in the host's `/etc/localtime` would make no difference. Setting the environment variable causes glibc to automatically lookup the timezone information, but without the tzdata package installed  it cannot obtain the information needed to understand the timezone requested, and fails back to displaying the time in UTC.

## How Has This Been Tested?
I remixed the container using this dockerfile:
```dockerfile
FROM docker.io/juanluisbaptiste/postfix
RUN apk add tzdata
```
I than ran the resulting image with environment variable `TZ=Europe/Berlin` and observed the time in the postfix startup message change and be correct comparing with a wall clock:

```
kandre@mainframe(pts/14) ~/t % cat env
SMTP_SERVER=localhost
SMTP_PORT=25
SERVER_HOSTNAME=containerized-postfix
TZ=Europe/Berlin
kandre@mainframe(pts/14) ~/t % podman run -ti --rm --env-file=env  docker.io/juanluisbaptiste/postfix                                              
Setting configuration option maillog_file with value: /dev/stdout
Setting configuration option myhostname with value: containerized-postfix
Setting configuration option mydomain with value: containerized-postfix.containerized-postfix
Setting configuration option mydestination with value: localhost
Setting configuration option myorigin with value: $mydomain
Setting configuration option relayhost with value: [localhost]:25
Setting configuration option smtp_use_tls with value: yes
Setting configuration option always_add_missing_headers with value: no
Setting configuration option smtp_host_lookup with value: native,dns
Setting configuration option inet_protocols with value: all
Setting configuration option mynetworks with value: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
/usr/sbin/postconf: warning: /etc/postfix/main.cf: support for parameter "smtp_use_tls" will be removed; instead, specify "smtp_tls_security_level"
postfix/postfix-script: starting the Postfix mail system
Nov 10 11:17:29 containerized-postfix postfix/master[1]: daemon started -- version 3.10.4, configuration /etc/postfix
kandre@mainframe(pts/14) ~/t % podman run -ti --rm --env-file=env  da08e4ef4cc28c20b67f52a27e2e10f1035a69f3ff6a624ffad95e416888a65d                
Setting configuration option maillog_file with value: /dev/stdout
Setting configuration option myhostname with value: containerized-postfix
Setting configuration option mydomain with value: containerized-postfix.containerized-postfix
Setting configuration option mydestination with value: localhost
Setting configuration option myorigin with value: $mydomain
Setting configuration option relayhost with value: [localhost]:25
Setting configuration option smtp_use_tls with value: yes
Setting configuration option always_add_missing_headers with value: no
Setting configuration option smtp_host_lookup with value: native,dns
Setting configuration option inet_protocols with value: all
Setting configuration option mynetworks with value: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
/usr/sbin/postconf: warning: /etc/postfix/main.cf: support for parameter "smtp_use_tls" will be removed; instead, specify "smtp_tls_security_level"
postfix/postfix-script: starting the Postfix mail system
Nov 10 12:17:37 containerized-postfix postfix/master[1]: daemon started -- version 3.10.4, configuration /etc/postfix
kandre@mainframe(pts/14) ~/t %                                                                                                                     
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.
