### PR TITLE
feat: Add support for defining an allowlist for recipients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@
 # Optional: This will use allow you to set a custom $mydestination value. Default is localhost.
 #DESTINATION=
 
+# Optional: This will allow to set an allowlist for recipients. Allow all recipients if unset.
+#RECIPIENT_ALLOWLIST=example@example.com example.org
+
 # Optional: This will output the subject line of messages in the log.
 #LOG_SUBJECT=yes
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The following env variable(s) are optional.
 
 * `DESTINATION` This will define a list of domains from which incoming messages will be accepted.
 
+* `RECIPIENT_ALLOWLIST` This will define a list of recipients or domains to which deliveries are permitted.
+
 * `LOG_SUBJECT` This will output the subject line of messages in the log.
 
 * `SMTPUTF8_ENABLE` This will enable (default) or disable support for SMTPUTF8. Valid values are `no` to disable and `yes` to enable. Not setting this variable will use the postfix default, which is `yes`.

--- a/run.sh
+++ b/run.sh
@@ -125,6 +125,17 @@ if [ ! -z "${MESSAGE_SIZE_LIMIT}" ]; then
   echo "Setting configuration option message_size_limit with value: ${MESSAGE_SIZE_LIMIT}"
 fi
 
+if [ ! -z "${RECIPIENT_ALLOWLIST}" ]; then
+  echo "Setting recipient allow list: ${RECIPIENT_ALLOWLIST}"
+  add_config_value "transport_maps" "lmdb://etc/postfix/transport"
+  IFS=', ' read -r -a recipient_allowlist_array <<< "${RECIPIENT_ALLOWLIST}"
+  for allowed_recipient in "${recipient_allowlist_array[@]}"; do
+    printf "%s :\n" "$allowed_recipient" >> /etc/postfix/transport
+  done
+  echo "* error: Not allowed recipient" >> /etc/postfix/transport
+  postmap /etc/postfix/transport
+fi
+
 #Start services
 
 # If host mounting /var/spool/postfix, we need to delete old pid file before


### PR DESCRIPTION
As this Postfix relay server doesn't require authentication to send emails, devices that aren't fully trusted could spam emails using this relay. And this could result in the IP address of the mail server being blacklisted.

To prevent this server being used to send spam messages, this patch implements an allowlist for recipients via the `RECIPIENT_ALLOWLIST` environment variable. This variable can contain a list of recipient addresses or domains separated by spaces or commas.

## Description of the change
This adds a `RECIPIENT_ALLOWLIST` environment variable, which allows to restrict allowed recipients to a certain allowlist.
Generally I use this postfix relay to allow devices, that either don't support TLS1.3 or for other reasons cannot send emails directly on my mail server.

However I also don't want to just allow any device to use my mail server to send anyone emails. I want to limit the allowed recipients or domains. This allows more control over what is allowed, thus it prevents rogue devices from sending spam, or accidentally sending/leaking emails to people outside of the organization.

## How Has This Been Tested?
I tested sending emails to allowed recipients and not allowed recipients, and the result was as expected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.
