### PR TITLE
fix: Avoid duplicate entries on /etc/postfix/header_checks on container restart

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -54,6 +54,9 @@ fi
 # Bind to both IPv4 and IPv4
 add_config_value "inet_protocols" "all"
 
+# Clear existing header_checks to avoid duplication on restart
+> /etc/postfix/header_checks
+
 # Create sasl_passwd file with auth credentials
 if [ ! -f /etc/postfix/sasl_passwd -a ! -z "${SMTP_USERNAME}" ]; then
   grep -q "${SMTP_SERVER}" /etc/postfix/sasl_passwd  > /dev/null 2>&1


### PR DESCRIPTION
## Description of the change

Fixes avoiding duplicate entries in `/etc/postfix/header_checks` file as PR #129 was trying to do, but in a more generic way that cover any other case where that file was or could be modified.

## Motivation and Context
Fixes the creation of duplicate entries in `/etc/postfix/header_checks` when the container is restarted.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My change adds a new configuration variable and I have updated the `.env.example` file accordingly.